### PR TITLE
Handle cluster without topics

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,3 +1,5 @@
+### 1.0.1
+* Fixed bug where connecting to a new Kafka cluster without any topics would fail
 ### 1.0.0
 * Fixed bug where high level consumer did not handle OffsetOutOfRange error, causing consuming to stop
 * Added consumer options to control consumer behaviour, like TcpTimeout, MaxBytes, MinBytes and WaitTime

--- a/src/Franz/Brokers.fs
+++ b/src/Franz/Brokers.fs
@@ -131,7 +131,9 @@ type BrokerRouter(tcpTimeout) as self =
                     |> Seq.map (fun (endPoint, nodeId) -> new Broker(nodeId, endPoint, getPartitions nodeId, tcpTimeout))
                     |> Seq.toList
             brokers |> Seq.iter (fun x -> x.LeaderFor <- getPartitions x.NodeId )
-            [ brokers; newBrokers ] |> Seq.concat |> Seq.toList
+            if brokers |> Seq.isEmpty && newBrokers |> Seq.isEmpty then
+                brokerSeeds |> Seq.map (fun x -> new Broker(-1, x, [||], tcpTimeout) ) |> Seq.toList
+            else [ brokers; newBrokers ] |> Seq.concat |> Seq.toList
         let rec connect seeds =
             match seeds with
             | head :: tail ->

--- a/src/Franz/HighLevel.fs
+++ b/src/Franz/HighLevel.fs
@@ -323,6 +323,7 @@ type Consumer(brokerSeeds, topicName, consumerOptions : ConsumerOptions, offsetM
         lowLevelRouter.GetAllBrokers() |> updateTopicPartitions
         lowLevelRouter.MetadataRefreshed.Add(fun x -> x |> updateTopicPartitions)
     new (brokerSeeds, topicName, consumerOptions, offsetManager) = Consumer(brokerSeeds, topicName, consumerOptions, offsetManager, [||])
+    new (brokerSeeds, topicName, offsetManager) = Consumer(brokerSeeds, topicName, new ConsumerOptions(), offsetManager, [||])
     /// Gets the offset manager
     member __.OffsetManager = offsetManager
     /// Consume messages from the topic specified in the consumer. This function returns a blocking IEnumerable.


### PR DESCRIPTION
When the metadata request doens't return any broker information, add the broker seeds to the list of available brokers. This happens when connecting to a Kafka cluster without any topics.