### PR TITLE
Minimize number of connections

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,5 +1,6 @@
 ### 2.0.2
 * Fix memory leak
+* Allow reusing BrokerRouter to minimize number of TCP connections to the cluster
 ### 2.0.1
 * Added missing getter and setter to offset storage
 ### 2.0.0


### PR DESCRIPTION
Allow reusing BrokerRouter to minimize number of TCP connections to the cluster