### PR TITLE
Offsetlogging

### DIFF
--- a/src/Franz/HighLevel.fs
+++ b/src/Franz/HighLevel.fs
@@ -397,10 +397,12 @@ type ConsumerOffsetManagerV2(topicName, brokerRouter : BrokerRouter) =
             coordinatorDictionary.TryUpdate(consumerGroup, getOffsetCoordinator consumerGroup, coordinator) |> ignore
             innerFetch consumerGroup
         | _ ->
-            partitions
-            |> Seq.filter (fun x -> x.ErrorCode.IsSuccess())
-            |> Seq.map (fun x -> { PartitionId = x.Id; Metadata = ""; Offset = x.Offset })
-            |> Seq.toArray
+            let offsets = partitions
+                            |> Seq.filter (fun x -> x.ErrorCode.IsSuccess())
+                            |> Seq.map (fun x -> { PartitionId = x.Id; Metadata = ""; Offset = x.Offset })
+                            |> Seq.toArray
+            LogConfiguration.Logger.Info.Invoke(sprintf "Offsets fetched from Kafka (using KafkaV2): %A" offsets)
+            offsets
 
     let rec innerCommit consumerGroup offsets =
         let coordinator = coordinatorDictionary.GetOrAdd(consumerGroup, getOffsetCoordinator)
@@ -422,7 +424,7 @@ type ConsumerOffsetManagerV2(topicName, brokerRouter : BrokerRouter) =
             let errorCode = (partitions |> Seq.tryFind (fun x -> x.ErrorCode <> ErrorCode.NoError))
             match errorCode with
             | Some x -> LogConfiguration.Logger.Error.Invoke(sprintf "Got error '%A' while commiting offset" x.ErrorCode, new Exception())
-            | None -> ()
+            | None -> LogConfiguration.Logger.Info.Invoke(sprintf "Offsets committed to Kafka (using KafkaV2): %A" offsets)
 
     do
         brokerRouter.Connect()

--- a/src/Franz/HighLevel.fs
+++ b/src/Franz/HighLevel.fs
@@ -200,6 +200,7 @@ type RoundRobinProducer(brokerRouter : BrokerRouter, compressionCodec : Compress
         member self.Dispose() = self.Dispose()
 
 /// Information about offsets
+[<StructuredFormatDisplay("Id: {PartitionId}, Offset: {Offset}, Metadata: {Metadata}")>]
 type PartitionOffset = { PartitionId : Id; Offset : Offset; Metadata : string }
 
 /// Interface for offset managers

--- a/src/Franz/HighLevel.fs
+++ b/src/Franz/HighLevel.fs
@@ -227,19 +227,24 @@ type ConsumerOffsetManagerV0(topicName, brokerRouter : BrokerRouter) =
         let partitions = brokerRouter.GetAvailablePartitionIds(topicName)
         let request = new OffsetFetchRequest(consumerGroup, [| { OffsetFetchRequestTopic.Name = topicName; Partitions = partitions } |], int16 0)
         let response = broker.Send(request)
-        response.Topics
-            |> Seq.filter (fun x -> x.Name = topicName)
-            |> Seq.map (fun x -> x.Partitions)
-            |> Seq.concat
-            |> Seq.filter (fun x -> x.ErrorCode.IsSuccess())
-            |> Seq.map (fun x -> { PartitionId = x.Id; Metadata = x.Metadata; Offset = x.Offset })
-            |> Seq.toArray
+        let offsets = response.Topics
+                        |> Seq.filter (fun x -> x.Name = topicName)
+                        |> Seq.map (fun x -> x.Partitions)
+                        |> Seq.concat
+                        |> Seq.filter (fun x -> x.ErrorCode.IsSuccess())
+                        |> Seq.map (fun x -> { PartitionId = x.Id; Metadata = x.Metadata; Offset = x.Offset })
+                        |> Seq.toArray
+        LogConfiguration.Logger.Info.Invoke(sprintf "Offsets fetched from Zookeeper: %A" offsets)
+        offsets
 
     let innerCommit offsets consumerGroup =
         let broker = brokerRouter.GetAllBrokers() |> Seq.head
         let partitions = offsets |> Seq.map (fun x -> { OffsetCommitRequestV0Partition.Id = x.PartitionId; Metadata = x.Metadata; Offset = x.Offset }) |> Seq.toArray
         let request = new OffsetCommitV0Request(consumerGroup, [| { OffsetCommitRequestV0Topic.Name = topicName; Partitions = partitions } |])
-        broker.Send(request)
+        let response = broker.Send(request)
+        if response.Topics |> Seq.exists (fun t -> t.Partitions |> Seq.exists (fun p -> p.ErrorCode.IsError())) then
+                invalidOp (sprintf "Got an error while commiting offsets. Response was %A" response)
+        if not (Seq.isEmpty offsets) then LogConfiguration.Logger.Info.Invoke(sprintf "Offsets committed to Zookeeper: %A" offsets)
 
     do
         brokerRouter.Connect()
@@ -255,9 +260,7 @@ type ConsumerOffsetManagerV0(topicName, brokerRouter : BrokerRouter) =
     /// Commit offset for the specified topic and partitions
     member __.Commit(consumerGroup, offsets) =
         if disposed then invalidOp "Offset manager has been disposed"
-        let response = refreshMetadataOnException (fun () -> innerCommit offsets consumerGroup)
-        if response.Topics |> Seq.exists (fun t -> t.Partitions |> Seq.exists (fun p -> p.ErrorCode.IsError())) then
-                invalidOp (sprintf "Got an error while commiting offsets. Response was %A" response)
+        refreshMetadataOnException (fun () -> innerCommit offsets consumerGroup)
     interface IConsumerOffsetManager with
         /// Fetch offset for the specified topic and partitions
         member self.Fetch(consumerGroup) = self.Fetch(consumerGroup)


### PR DESCRIPTION
This PR is for adding logging when fetching and committing offsets for better traceability.

Here is an example of how a resulting log could look like with these changes.


[21-04-2016 22:07:45] Info    Adding broker with endpoint {Address = "testkafka205.prod.local";
 Port = 9092;}
[21-04-2016 22:07:45] Info    Offsets fetched from Zookeeper: [|Id: 2, Offset: 0L, Metadata: ; Id: 1, Offset: 0L, Metadata: ;
  Id: 0, Offset: 0L, Metadata: |]
[21-04-2016 22:07:53] Info    Offsets committed to Zookeeper: [|Id: 0, Offset: 1602019L, Metadata: ; Id: 1, Offset: 1601141L, Metadata: ;
  Id: 2, Offset: 1593599L, Metadata: |]

