### PR TITLE
Handle tcp client connection error

### DIFF
--- a/src/Franz/Brokers.fs
+++ b/src/Franz/Brokers.fs
@@ -65,8 +65,12 @@ type Broker(nodeId : Id, endPoint : EndPoint, leaderFor : TopicPartitionLeader a
             try
                 send self request
             with
+            | :? InvalidOperationException as e ->
+                LogConfiguration.Logger.Info.Invoke(sprintf "Broker connection in bad state, unable to send due to handled exception: %s" (e.ToString()))
+                self.Connect()
+                send self request
             | e ->
-                LogConfiguration.Logger.Info.Invoke(sprintf "Broker unable to send: %s" (e.ToString()))
+                LogConfiguration.Logger.Warning.Invoke(sprintf "Broker unable to send due to unhandled exception: %s" (e.ToString()))
                 self.Connect()
                 send self request
             )

--- a/src/Franz/Brokers.fs
+++ b/src/Franz/Brokers.fs
@@ -73,11 +73,9 @@ type Broker(nodeId : Id, endPoint : EndPoint, leaderFor : TopicPartitionLeader a
             with
             | :? UnderlyingConnectionClosedException as e ->
                 LogConfiguration.Logger.Info.Invoke(sprintf "Broker connection in bad state, unable to send due to handled exception: %s" (e.ToString()))
-                self.Connect()
                 send self request
             | e ->
                 LogConfiguration.Logger.Warning.Invoke(sprintf "Broker unable to send due to unhandled exception: %s" (e.ToString()))
-                self.Connect()
                 send self request
             )
         request.DeserializeResponse(rawResponseStream)

--- a/src/Franz/Brokers.fs
+++ b/src/Franz/Brokers.fs
@@ -71,7 +71,7 @@ type Broker(nodeId : Id, endPoint : EndPoint, leaderFor : TopicPartitionLeader a
             try
                 send self request
             with
-            | :? InvalidOperationException as e ->
+            | :? UnderlyingConnectionClosedException as e ->
                 LogConfiguration.Logger.Info.Invoke(sprintf "Broker connection in bad state, unable to send due to handled exception: %s" (e.ToString()))
                 self.Connect()
                 send self request

--- a/src/Franz/Brokers.fs
+++ b/src/Franz/Brokers.fs
@@ -48,6 +48,7 @@ type Broker(nodeId : Id, endPoint : EndPoint, leaderFor : TopicPartitionLeader a
     /// Connect the broker
     member __.Connect() =
         if disposed then invalidOp "Broker has been disposed"
+        LogConfiguration.Logger.Info.Invoke("Creating new tcp connecting...")
         try
             client <- new TcpClient()
             client.ReceiveTimeout <- tcpTimeout

--- a/src/Franz/Brokers.fs
+++ b/src/Franz/Brokers.fs
@@ -68,12 +68,7 @@ type Broker(nodeId : Id, endPoint : EndPoint, leaderFor : TopicPartitionLeader a
             | e ->
                 LogConfiguration.Logger.Info.Invoke(sprintf "Broker unable to send: %s" (e.ToString()))
                 self.Connect()
-                try
-                    send self request
-                with
-                | _ ->
-                    client <- null
-                    reraise()
+                send self request
             )
         request.DeserializeResponse(rawResponseStream)
     /// Closes the connection and disposes the broker

--- a/src/Franz/Brokers.fs
+++ b/src/Franz/Brokers.fs
@@ -66,8 +66,7 @@ type Broker(nodeId : Id, endPoint : EndPoint, leaderFor : TopicPartitionLeader a
                 send self request
             with
             | e ->
-                LogConfiguration.Logger.Warning.Invoke(sprintf "Got exception while sending request: %s" (e.ToString()) )
-                LogConfiguration.Logger.Info.Invoke("Reconnecting...")
+                LogConfiguration.Logger.Info.Invoke(sprintf "Broker unable to send: %s" (e.ToString()))
                 self.Connect()
                 try
                     send self request

--- a/src/Franz/Stream.fs
+++ b/src/Franz/Stream.fs
@@ -4,6 +4,8 @@ open System
 open System.IO
 open System.Text
 
+exception UnderlyingConnectionClosedException of string
+
 /// Writes to a stream conforming to the Kafka protocol
 [<AbstractClass; Sealed>]
 type BigEndianWriter() =
@@ -60,7 +62,7 @@ type BigEndianReader() =
         let bytesRead = stream.Read(buffer, offset, bytesLeft)
         if bytesRead <> bytesLeft then
             if bytesRead = 0 then
-                invalidOp "Could not read data from stream as connection has been closed"
+                raise(UnderlyingConnectionClosedException "Could not read any data from stream")
             readLoop (offset + bytesRead) (bytesLeft - bytesRead) stream buffer
 
     /// Convert an array to big endian if needed


### PR DESCRIPTION
We down grade from warning to info in specific case, since it is a known fact that a TCP client/socket in .net might have lost connectivity due to ex. TTL and the Connected property only displays state from last operation and not current tcp connection state.
We choose to handle the specific "System.InvalidOperationException: Could not read data from stream as connection has been closed" as INFO since this is the known case.
Other exceptions are still WARNING.

Only gotcha is wether the client <- null and reraise have any importance/value?