### PR TITLE
Move endpoint out of internal namespace

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -4,6 +4,7 @@
 * Topic has been moved to consumer options, meaning that consumers no longer needs this argument in the constructor.
 * Consumers now all take arguments in the same order.
 * Brokerseeds are now defined be IEnumerable of EndPoint instead of array
+* EndPoint is move into Franz namespace instead of Franz.Internal
 
 **Other changes**
 

--- a/src/Franz/Infrastructure.fs
+++ b/src/Franz/Infrastructure.fs
@@ -1,81 +1,83 @@
-﻿namespace Franz.Internal
+﻿namespace Franz
 
-/// Type alias for MailBoxProcessor
-type Agent<'T> = MailboxProcessor<'T>
+    /// A endpoint
+    type EndPoint = 
+        { Address : string
+          Port : int32 }    
 
-/// A endpoint
-type EndPoint = 
-    { Address : string
-      Port : int32 }
+namespace Franz.Internal
 
-[<AutoOpen>]
-module Seq = 
-    /// Function to handle round robin
-    let roundRobin lastPos list = 
-        let length = list |> Seq.length
-        if (lastPos < length - 1) then 
-            let pos = lastPos + 1
-            (pos, list |> Seq.item pos)
-        else (0, list |> Seq.head)
+    /// Type alias for MailBoxProcessor
+    type Agent<'T> = MailboxProcessor<'T>
 
-[<AutoOpen>]
-module Array = 
-    let rand = new System.Random()
-    
-    let swap (a : _ []) x y = 
-        let tmp = a.[x]
-        a.[x] <- a.[y]
-        a.[y] <- tmp
-    
-    // shuffle an array (in-place)
-    let shuffle a = Array.iteri (fun i _ -> swap a i (rand.Next(i, Array.length a))) a
+    [<AutoOpen>]
+    module Seq = 
+        /// Function to handle round robin
+        let roundRobin lastPos list = 
+            let length = list |> Seq.length
+            if (lastPos < length - 1) then 
+                let pos = lastPos + 1
+                (pos, list |> Seq.item pos)
+            else (0, list |> Seq.head)
 
-module Retry = 
-    let retryOnException (state : 'a) (onException : exn -> 'a) (f : 'a -> 'b) : 'b = 
-        try 
-            state |> f
-        with e -> 
-            let newState = onException (e)
-            f (newState)
+    [<AutoOpen>]
+    module Array = 
+        let rand = new System.Random()
+    
+        let swap (a : _ []) x y = 
+            let tmp = a.[x]
+            a.[x] <- a.[y]
+            a.[y] <- tmp
+    
+        // shuffle an array (in-place)
+        let shuffle a = Array.iteri (fun i _ -> swap a i (rand.Next(i, Array.length a))) a
 
-[<AutoOpen>]
-module ExceptionUtilities = 
-    open System
-    open Franz
-    
-    let raiseWithErrorLog (someExceptionToRaise : exn) = 
-        LogConfiguration.Logger.Error.Invoke(someExceptionToRaise.Message, someExceptionToRaise)
-        raise (someExceptionToRaise)
-    
-    let raiseWithFatalLog (someExceptionToRaise : exn) = 
-        LogConfiguration.Logger.Fatal.Invoke(someExceptionToRaise.Message, someExceptionToRaise)
-        raise (someExceptionToRaise)
-    
-    let raiseIfDisposed (disposed : bool) = 
-        if disposed then 
-            raiseWithFatalLog 
-                (ObjectDisposedException 
-                     "Illegal attempt made by calling af function on type which have been marked as disposed")
+    module Retry = 
+        let retryOnException (state : 'a) (onException : exn -> 'a) (f : 'a -> 'b) : 'b = 
+            try 
+                state |> f
+            with e -> 
+                let newState = onException (e)
+                f (newState)
 
-module internal ErrorHandling = 
-    type Result<'a, 'b> = 
-        | Success of 'a
-        | Failure of 'b
+    [<AutoOpen>]
+    module ExceptionUtilities = 
+        open System
+        open Franz
     
-    let catch f x = 
-        try 
-            f x |> Success
-        with e -> e |> Failure
+        let raiseWithErrorLog (someExceptionToRaise : exn) = 
+            LogConfiguration.Logger.Error.Invoke(someExceptionToRaise.Message, someExceptionToRaise)
+            raise (someExceptionToRaise)
     
-    let fail x = x |> Failure
-    let succeed x = x |> Success
+        let raiseWithFatalLog (someExceptionToRaise : exn) = 
+            LogConfiguration.Logger.Fatal.Invoke(someExceptionToRaise.Message, someExceptionToRaise)
+            raise (someExceptionToRaise)
     
-    let either fSuccess fFailure result = 
-        match result with
-        | Success x -> fSuccess x
-        | Failure x -> fFailure x
+        let raiseIfDisposed (disposed : bool) = 
+            if disposed then 
+                raiseWithFatalLog 
+                    (ObjectDisposedException 
+                         "Illegal attempt made by calling af function on type which have been marked as disposed")
 
-[<AutoOpenAttribute>]
-module Map = 
-    let getValues (x : Map<_, _>) = x |> Seq.map (fun x -> x.Value)
-    let getKeys (x : Map<_, _>) = x |> Seq.map (fun x -> x.Key)
+    module internal ErrorHandling = 
+        type Result<'a, 'b> = 
+            | Success of 'a
+            | Failure of 'b
+    
+        let catch f x = 
+            try 
+                f x |> Success
+            with e -> e |> Failure
+    
+        let fail x = x |> Failure
+        let succeed x = x |> Success
+    
+        let either fSuccess fFailure result = 
+            match result with
+            | Success x -> fSuccess x
+            | Failure x -> fFailure x
+
+    [<AutoOpenAttribute>]
+    module Map = 
+        let getValues (x : Map<_, _>) = x |> Seq.map (fun x -> x.Value)
+        let getKeys (x : Map<_, _>) = x |> Seq.map (fun x -> x.Key)

--- a/tests/Franz.Integration.Tests/Cluster.fs
+++ b/tests/Franz.Integration.Tests/Cluster.fs
@@ -5,7 +5,7 @@ open System.Diagnostics
 open System.IO
 open System.Threading
 open System.Text
-open Franz.Internal
+open Franz
 
 let kafka_brokers = 
     [| { Address = "192.168.100.100"


### PR DESCRIPTION
This type is not internal, and should not be placed in the Internal namespace.
This PR is based upon #73, and should not be merged before this PR is merged